### PR TITLE
Add untranslated(developer) review mode

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,10 +8,11 @@ import { inspect, promisify } from 'util';
 
 const readFileAsync = promisify(readFile);
 
-type InputMode = 'translated' | 'reviewed' | 'proofread';
-type TxMode = 'translated' | 'reviewed' | 'reviewed2';
+type InputMode = 'untranslated' | 'translated' | 'reviewed' | 'proofread';
+type TxMode = 'developer' | 'translated' | 'reviewed' | 'reviewed2' ;
 
 const MODE_MAP: { [x in InputMode]: TxMode } = {
+  untranslated: 'developer',
   translated: 'translated',
   reviewed: 'reviewed',
   proofread: 'reviewed2'


### PR DESCRIPTION
We are switching our translation tool to transifex. All languages were not translated (and are still not), and we need default values (those from the source language file). So this PR add an 'untranslated' mode

Could you also do the release of a new version, please? I can also do it if it ok with you (it only needs to run the release script from a release branch, with an increased version in package.json, right?) 

Thank you very much guys!