### PR TITLE
Replace old API pull modes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: "fr,de,nl,es"
     required: true
   mode:
-    description: "Mode to pull translations (untranslated, translated, reviewed, proofread)"
+    description: "Mode to pull translations ('default', 'reviewed', 'proofread', 'translator', 'untranslated', 'onlytranslated', 'onlyreviewed', 'onlyproofread', 'sourceastranslation'"
     default: "reviewed"
     required: true
   branch:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,15 +8,16 @@ import { inspect, promisify } from 'util';
 
 const readFileAsync = promisify(readFile);
 
-export type InputMode = 'untranslated' | 'translated' | 'reviewed' | 'proofread';
-export type TxMode = 'developer' | 'translated' | 'reviewed' | 'reviewed2' ;
-
-const MODE_MAP: { [x in InputMode]: TxMode } = {
-  untranslated: 'developer',
-  translated: 'translated',
-  reviewed: 'reviewed',
-  proofread: 'reviewed2'
-};
+export type InputMode =
+    'default'
+    | 'reviewed'
+    | 'proofread'
+    | 'translator'
+    | 'untranslated'
+    | 'onlytranslated'
+    | 'onlyreviewed'
+    | 'onlyproofread'
+    | 'sourceastranslation';
 
 /**
  * Runs a shell command and dumps the output to the GitHub Actions log
@@ -40,7 +41,9 @@ const runShellCommand = async (commandString: string) => {
  * @param project The project namespace, i.e.: retail-pos-web
  * @param resource The resource name, i.e.: retail-reports
  * @param languages The languages to pull, i.e.: ['fr', 'de']
- * @param mode "translated" | "reviewed" | "proofread"
+ * @param mode The translation mode of the downloaded file. This can be one of the following:
+ * 'default', 'reviewed', 'proofread', 'translator', 'untranslated',
+ * 'onlytranslated', 'onlyreviewed', "'onlyproofread', 'sourceastranslation'
  * @param branch Base branch to pull changes from reading the correct .tx/config
  */
 export const pullTranslations = async (
@@ -59,7 +62,7 @@ export const pullTranslations = async (
   }
 
   await runShellCommand(
-    `tx pull --mode ${MODE_MAP[mode]} -f -l ${languages.join(
+    `tx pull --mode ${mode} -f -l ${languages.join(
       ','
     )} -r ${fullResource}`
   );
@@ -94,7 +97,9 @@ export const pushChangesToRemote = async (
  * @param project The project namespace, i.e.: retail-pos-web
  * @param resource The resource name, i.e.: retail-reports
  * @param languages The languages to pull, i.e.: ['fr', 'de']
- * @param mode "translated" | "reviewed" | "proofread"
+ * @param mode The translation mode of the downloaded file. This can be one of the following:
+ * 'default', 'reviewed', 'proofread', 'translator', 'untranslated',
+ * 'onlytranslated', 'onlyreviewed', "'onlyproofread', 'sourceastranslation'
  * @param branch The base branch to create the PR
  */
 export const createPullRequest = async (


### PR DESCRIPTION
This PR drops support for the old API modes and adds the newer ones.

Current support list can be found [here](https://github.com/transifex/cli/blob/0467f0aad4ea715af0d080540f3e724dfd7f6da6/cmd/tx/main.go#L291-L300).

```
					&cli.StringFlag{
						Name:    "mode",
						Aliases: []string{"m"},
						Value:   "default",
						Usage: "The translation mode of the downloaded " +
							"file. This can be one of the following:\n    " +
							"'default', 'reviewed', 'proofread', " +
							"'translator', 'untranslated',\n    " +
							"'onlytranslated', 'onlyreviewed', " +
							"'onlyproofread', 'sourceastranslation'",
					},
```

Since the Transifex also changed some of the previously confusing names (reviewed2), I don't see the need for the additional mapping anymore. 

Potential issues:
- translated is now translator
- untranslated was developer
